### PR TITLE
Removed 'M-BM-' characters

### DIFF
--- a/Linux/shinyGUI/server.R
+++ b/Linux/shinyGUI/server.R
@@ -329,7 +329,7 @@ shinyServer(function(input, output) {
 		levels(Data1$testref)=c("Test Sample","Reference Sample","Affected exon")
 		new_cols=c("blue","gray","red")
                 	
-                A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref)) 
+                A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))
                 A1<-A1 + geom_point(cex=2.5,lwd=1.5) 
                 A1<-A1 + scale_colour_manual(values=new_cols)  
                 A1<-A1 + geom_line(data=subset(Data1,testref=="Reference Sample"),lty="dashed",lwd=1.5,col="grey") 
@@ -378,7 +378,7 @@ shinyServer(function(input, output) {
 		    levels(Data1$testref)=c("Test Sample","Reference Sample","Affected exon")
     		    new_cols=c("blue","gray","red")
 					
-                    A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))  
+                    A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))
                     A1<-A1 + geom_point(cex=2.5,lwd=1.5) 
                     A1<-A1 + scale_colour_manual(values=new_cols)  
                     A1<-A1 + geom_line(data=subset(Data1,testref=="Reference Sample"),lty="dashed",lwd=1.5,col="grey") 
@@ -426,7 +426,7 @@ shinyServer(function(input, output) {
 		    levels(Data1$testref)=c("Test Sample","Affected exon")
 		    new_cols=c("blue","red")
                 	
-                    A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))  
+                    A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))
                     A1<-A1 + geom_point(cex=2.5,lwd=1.5) 
                     A1<-A1 + scale_colour_manual(values=new_cols) 
                     A1<-A1 + geom_line(data=subset(Data1,testref=="Test Sample"),lty="dashed",lwd=1.5,col="blue") 

--- a/Windows/scripts/shinyGUI/server.R
+++ b/Windows/scripts/shinyGUI/server.R
@@ -329,7 +329,7 @@ shinyServer(function(input, output) {
 		levels(Data1$testref)=c("Test Sample","Reference Sample","Affected exon")
 		new_cols=c("blue","gray","red")
                 	
-                A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref)) 
+                A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))
                 A1<-A1 + geom_point(cex=2.5,lwd=1.5) 
                 A1<-A1 + scale_colour_manual(values=new_cols)  
                 A1<-A1 + geom_line(data=subset(Data1,testref=="Reference Sample"),lty="dashed",lwd=1.5,col="grey") 
@@ -378,7 +378,7 @@ shinyServer(function(input, output) {
 		    levels(Data1$testref)=c("Test Sample","Reference Sample","Affected exon")
     		    new_cols=c("blue","gray","red")
 					
-                    A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))  
+                    A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))
                     A1<-A1 + geom_point(cex=2.5,lwd=1.5) 
                     A1<-A1 + scale_colour_manual(values=new_cols)  
                     A1<-A1 + geom_line(data=subset(Data1,testref=="Reference Sample"),lty="dashed",lwd=1.5,col="grey") 
@@ -426,7 +426,7 @@ shinyServer(function(input, output) {
 		    levels(Data1$testref)=c("Test Sample","Affected exon")
 		    new_cols=c("blue","red")
                 	
-                    A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))  
+                    A1<-ggplot(data=Data1,aes(x=exonRange,y=value,group=variable,colour=testref))
                     A1<-A1 + geom_point(cex=2.5,lwd=1.5) 
                     A1<-A1 + scale_colour_manual(values=new_cols) 
                     A1<-A1 + geom_line(data=subset(Data1,testref=="Test Sample"),lty="dashed",lwd=1.5,col="blue") 


### PR DESCRIPTION
Removed 'M-BM-' characters from Linux/shinyGUI/server.R and Windows/scripts/shinyGUI/server.r and replaced them with ordinary spaces. 

These were causing errors when running the Linux server. After making this change I was able to successfully complete the full analysis process in Linux using the test data set (https://github.com/RahmanTeam/DECoN-test-files/releases/tag/v1.0.0). I've only tested the fix on Linux.

Before:
![image](https://cloud.githubusercontent.com/assets/8166553/21266523/80dec040-c39e-11e6-98b3-a60dc2efa143.png)

shiny is greyed out and unresponsive:
![image](https://cloud.githubusercontent.com/assets/8166553/21267254/7e6f11a4-c3a1-11e6-84e6-3f234739b582.png)

The culprit:
![image](https://cloud.githubusercontent.com/assets/8166553/21267044/78c00dcc-c3a0-11e6-86f9-c1dc86b50081.png)

After:
![image](https://cloud.githubusercontent.com/assets/8166553/21267128/e0a866fa-c3a0-11e6-82c1-b806487e0179.png)

shiny is working correctly:
![image](https://cloud.githubusercontent.com/assets/8166553/21267290/9885ff44-c3a1-11e6-83da-d27e3fdd7573.png)
